### PR TITLE
switch to modernc sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Rousseau Toolbox
 
 A household toolbox starting with a budgeting app. The project is built in Go and follows a hexagonal architecture. It serves a small dashboard using Go templates and SQLite (pure Go driver).
+It uses the upstream modernc.org/sqlite driver.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/glebarez/sqlite"
+	_ "modernc.org/sqlite"
 
 	"github.com/bootstrappedsoftware/rousseau_toolbox/internal/adapters/repository/sqlite"
 	"github.com/bootstrappedsoftware/rousseau_toolbox/internal/adapters/web"
@@ -32,7 +32,7 @@ func main() {
 
 	repo := sqlite.NewRepo(db)
 	svc := usecase.NewBudgetService(repo)
-	server := http.NewServer(svc)
+	server := web.NewServer(svc)
 
 	addr := fmt.Sprintf(":%s", port)
 	log.Printf("server listening on %s", addr)

--- a/codemap.md
+++ b/codemap.md
@@ -8,3 +8,4 @@
 - `internal/database` - database setup and migrations.
 - `migrations` - SQL migration files.
 - `internal/adapters/web/templates` - HTML templates for the web adapter.
+- Uses the upstream modernc.org/sqlite pure Go SQLite driver.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/bootstrappedsoftware/rousseau_toolbox
 
 go 1.21
 
-require (
-    github.com/glebarez/sqlite v0.0.0
-)
-
+require modernc.org/sqlite v1.25.0

--- a/internal/adapters/repository/sqlite/budget_test.go
+++ b/internal/adapters/repository/sqlite/budget_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/glebarez/sqlite"
+	_ "modernc.org/sqlite"
 )
 
 func TestRepo(t *testing.T) {

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/glebarez/sqlite"
+	_ "modernc.org/sqlite"
 )
 
 func TestRunMigrations(t *testing.T) {


### PR DESCRIPTION
## Summary
- use the upstream modernc.org/sqlite driver
- drop the local driver stub
- keep codemap updated

## Testing
- `go test ./...` *(fails: missing go.sum entry)*
- `go mod tidy` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6878dcb716108331adfdf6aff693ca9d